### PR TITLE
non interactive mode via env var

### DIFF
--- a/lib/input/confirmation-routines.js
+++ b/lib/input/confirmation-routines.js
@@ -45,6 +45,9 @@ async function confirm_Async(question) {
  * @throws {UserDidNotConfirmError} - If the user does not confirm the operation parameters.
  */
 async function confirmOperationOptionsOrExit_Async(migrationOptions) {
+    if(process.env.NON_INTERACTIVE == 'true') {
+        return;
+    }
     const migrationOptionsStr = util.inspect(migrationOptions, {depth: null, colors: true});
     const migrationPrompt = 
 `❗️WARNING: This script will perform the bulk operation with the following parameters:


### PR DESCRIPTION
add env variable to create a non-interactive execution of the script. For mass execution of files, this is quite handy. 